### PR TITLE
Fix autoscaling_enabled broken

### DIFF
--- a/workers.tf
+++ b/workers.tf
@@ -95,7 +95,7 @@ resource "aws_autoscaling_group" "workers" {
           var.worker_groups[count.index],
           "autoscaling_enabled",
           local.workers_group_defaults["autoscaling_enabled"],
-        ) == 1 ? "enabled" : "disabled"}"
+        ) ? "enabled" : "disabled"}"
         "value"               = "true"
         "propagate_at_launch" = false
       },

--- a/workers_launch_template.tf
+++ b/workers_launch_template.tf
@@ -114,7 +114,7 @@ resource "aws_autoscaling_group" "workers_launch_template" {
           var.worker_groups_launch_template[count.index],
           "autoscaling_enabled",
           local.workers_group_defaults["autoscaling_enabled"],
-        ) == 1 ? "enabled" : "disabled"}"
+        ) ? "enabled" : "disabled"}"
         "value"               = "true"
         "propagate_at_launch" = false
       },

--- a/workers_launch_template_mixed.tf
+++ b/workers_launch_template_mixed.tf
@@ -183,7 +183,7 @@ resource "aws_autoscaling_group" "workers_launch_template_mixed" {
           var.worker_groups_launch_template_mixed[count.index],
           "autoscaling_enabled",
           local.workers_group_defaults["autoscaling_enabled"],
-        ) == 1 ? "enabled" : "disabled"}"
+        ) ? "enabled" : "disabled"}"
         "value"               = "true"
         "propagate_at_launch" = false
       },


### PR DESCRIPTION
`autoscaling_enabled` is broken because bool will be converted to string value,

maybe is caused by the type constraints:
```diff
variable "worker_groups" {
  description = "A list of maps defining worker group configurations to be defined using AWS Launch Configurations. See workers_group_defaults for valid keys."
+  type        = list(map(string))

  default = [
    {
      "name" = "default"
    },
  ]
}
```
